### PR TITLE
Wrap README prose at 80 columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # neeto-course-GitHub-starter-template
 
-If you are using [NeetoCourse](https://www.neeto.com/neetocourse) and want your course materials to be in GitHub then
-this repo serves as the template repo. You can fork this repo and you can make the necessary changes.
+If you are using [NeetoCourse](https://www.neeto.com/neetocourse) and want your
+course materials to be in GitHub then this repo serves as the template repo. You
+can fork this repo and you can make the necessary changes.
 
 ## Repo Structure
 
-Refer to [this documentation](https://neetocoursehelp.neetokb.com/p/a-b68add58) to learn about how you need to structure your GitHub repo.
+Refer to [this documentation](https://neetocoursehelp.neetokb.com/p/a-b68add58)
+to learn about how you need to structure your GitHub repo.


### PR DESCRIPTION
Wraps prose in `README.md` at 80 columns so it stops scrolling
horizontally in editors without soft wrap.

Only paragraph text is rewrapped. Code blocks, tables, headings, URLs and
HTML are left byte for byte alone, and the rendered output is unchanged.

Opened by `gh-repo-compliancy`.
