### PR TITLE
Revert "Wrap README prose at 80 columns"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # neeto-course-GitHub-starter-template
 
-If you are using [NeetoCourse](https://www.neeto.com/neetocourse) and want your
-course materials to be in GitHub then this repo serves as the template repo. You
-can fork this repo and you can make the necessary changes.
+If you are using [NeetoCourse](https://www.neeto.com/neetocourse) and want your course materials to be in GitHub then
+this repo serves as the template repo. You can fork this repo and you can make the necessary changes.
 
 ## Repo Structure
 
-Refer to [this documentation](https://neetocoursehelp.neetokb.com/p/a-b68add58)
-to learn about how you need to structure your GitHub repo.
+Refer to [this documentation](https://neetocoursehelp.neetokb.com/p/a-b68add58) to learn about how you need to structure your GitHub repo.


### PR DESCRIPTION
**Description**

- Removed: reverts the 80-column README prose wrapping.

Restores `README.md` to its content from before the wrap commit, taken from git
history (the parent of that commit) rather than from a working copy.

Reverting so the wrapping can be redone at 120 columns from the original text.
Re-wrapping the already-wrapped file is not equivalent — wrapping at 80 can
split a line so short that re-wrapping at 120 cannot rejoin it, which affects 5
of 266 READMEs. Going back to the original avoids that.

Only `README.md` is touched.

**Checklist**

- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added the necessary label (patch/minor/major - If package publish is required).
- [x] I have followed the suggested description format and styling.

**Reviewers**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
