### PR TITLE
Wrap README prose at 120 columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,5 @@ this repo serves as the template repo. You can fork this repo and you can make t
 
 ## Repo Structure
 
-Refer to [this documentation](https://neetocoursehelp.neetokb.com/p/a-b68add58) to learn about how you need to structure your GitHub repo.
+Refer to [this documentation](https://neetocoursehelp.neetokb.com/p/a-b68add58) to learn about how you need to structure
+your GitHub repo.


### PR DESCRIPTION
Wraps prose in `README.md` at 120 columns so it stops scrolling
horizontally in editors without soft wrap.

Only paragraph text is rewrapped. Code blocks, tables, headings, URLs and
HTML are left byte for byte alone, and the rendered output is unchanged.

Opened by `gh-repo-compliancy`.
